### PR TITLE
add benchmarks

### DIFF
--- a/sonyflake_test.go
+++ b/sonyflake_test.go
@@ -190,3 +190,25 @@ func TestNextIDError(t *testing.T) {
 		t.Errorf("time is not over")
 	}
 }
+
+func BenchmarkNextID(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, _ = sf.NextID()
+	}
+}
+
+func BenchmarkNextID_validate(b *testing.B) {
+	m := map[uint64]struct{}{}
+	for i := 0; i < b.N; i++ {
+		id, err := sf.NextID()
+		if err != nil {
+			b.Logf("NextID returned err:%v", err)
+			b.FailNow()
+		}
+		m[id] = struct{}{}
+	}
+	if len(m) != b.N {
+		b.Logf("duplicated ids")
+		b.FailNow()
+	}
+}


### PR DESCRIPTION
```
$ go test  -bench=.
sonyflake id: 838861161
decompose: map[id:838861161 machine-id:361 msb:0 sequence:0 time:50]
max sequence: 255
number of id: 256000
number of cpu: 8
number of id: 100000
goos: linux
goarch: amd64
pkg: github.com/sony/sonyflake
BenchmarkNextID-8            	   50000	     38984 ns/op
--- FAIL: BenchmarkNextID_validate
    sonyflake_test.go:205: NextID returned err:over the time limit
FAIL
exit status 1
FAIL	github.com/sony/sonyflake	16.740s
```