### PR TITLE
Add config to use all 64 bits

### DIFF
--- a/sonyflake_test.go
+++ b/sonyflake_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 var sf *Sonyflake
+var sfu *Sonyflake
 
 var startTime int64
 var machineID uint64
@@ -24,6 +25,12 @@ func init() {
 	sf = NewSonyflake(st)
 	if sf == nil {
 		panic("sonyflake not created")
+	}
+
+	st.Use64Bits = true
+	sfu = NewSonyflake(st)
+	if sfu == nil {
+		panic("uint sonyflake not created")
 	}
 
 	startTime = toSonyflakeTime(st.StartTime)
@@ -206,6 +213,7 @@ func TestSonyflakeInParallel(t *testing.T) {
 
 func pseudoSleep(period time.Duration) {
 	sf.startTime -= int64(period) / sonyflakeTimeUnit
+	sfu.startTime -= int64(period) / sonyflakeTimeUnit
 }
 
 func TestNextIDError(t *testing.T) {
@@ -217,6 +225,16 @@ func TestNextIDError(t *testing.T) {
 	_, err := sf.NextID()
 	if err == nil {
 		t.Errorf("time is not over")
+	}
+	_, err = sfu.NextID()
+	if err != nil {
+		t.Error("uint id not generated")
+	}
+
+	pseudoSleep(time.Duration(174) * year)
+	_, err = sfu.NextID()
+	if err == nil {
+		t.Errorf("uint time is not over")
 	}
 }
 


### PR DESCRIPTION
Add `Use64Bits` to Settings. When true, the bit length used for time will be 40 instead of 39. This allows for the generation of unique IDs for over 348 years from the start date.

Done by adding the `bitLenTime` field to the Sonyflake struct and using its value (39 or 40) to detect time overflows, rather than the constant `BitLenTime`. The new constant `BitLenTimeUint` is set to 40.

Update docs and note that values converted to `int64` after 174 years will be negative.

