### PR TITLE
Use net.IP.Equal instead of bytes.Equal

### DIFF
--- a/sonyflake_test.go
+++ b/sonyflake_test.go
@@ -1,7 +1,6 @@
 package sonyflake
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"net"
@@ -259,7 +258,7 @@ func TestPrivateIPv4(t *testing.T) {
 				return
 			}
 
-			if bytes.Equal(actual, tc.expected) {
+			if net.IP.Equal(actual, tc.expected) {
 				return
 			} else {
 				t.Errorf("error: expected: %s, but got: %s", tc.expected, actual)


### PR DESCRIPTION
As suggested by go-staticcheck. Appears to be [present in Go since at least v1](https://pkg.go.dev/net@go1#IP.Equal).